### PR TITLE
ET_interface: add Makefile based build for ET

### DIFF
--- a/ET_interface/thorns/RePrimAnd/dist/Makefile
+++ b/ET_interface/thorns/RePrimAnd/dist/Makefile
@@ -1,0 +1,23 @@
+# Simple Makefile for use with the ET's auto-buid mechanism
+SUBDIRS:=$(wildcard */)
+SOURCES:=$(wildcard $(patsubst %,%/*.cc,$(SUBDIRS)))
+INCLUDES:=$(wildcard $(patsubst %,%/include/*.h,$(SUBDIRS)))
+OBJECTS:=$(patsubst %.cc,%.o,$(SOURCES))
+
+CXXFLAGS+=$(patsubst %,-I%/include,$(SUBDIRS))
+CXXFLAGS+=$(patsubst %,-I%,$(BOOST_INC_DIRS) $(GSL_INC_DIRS) $(HDF5_INC_DIRS))
+
+all: libRePrimAnd.a $(INCLUDES)
+
+install: all
+	mkdir -p $(DESTDIR)/include/reprimand $(DESTDIR)/lib
+	cp libRePrimAnd.a $(DESTDIR)/lib
+	cp $(INCLUDES) $(DESTDIR)/include/reprimand
+
+libRePrimAnd.a: $(OBJECTS)
+	$(AR) $(ARFLAGS) $@ $^
+
+clean:
+	$(RM) $(OBJECTS) libRePrimAnd.a
+
+.PHONY: all install clean

--- a/ET_interface/thorns/RePrimAnd/src/build.sh
+++ b/ET_interface/thorns/RePrimAnd/src/build.sh
@@ -41,19 +41,18 @@ rm -rf ${BUILD_DIR} ${INSTALL_DIR}
 mkdir ${BUILD_DIR} ${INSTALL_DIR}
 
 echo "REPRIMAND: Unpacking archive..."
-pushd ${BUILD_DIR}
+pushd ${BUILD_DIR} >/dev/null
 ${TAR?} xJf ${SRCDIR}/../dist/${NAME}.tar.xz
 
 echo "REPRIMAND: Configuring..."
-cd ${NAME}
-meson setup mesonbuild --libdir=lib --prefix=${REPRIMAND_DIR} --default-library=static --buildtype=debugoptimized -Dbuild_documentation=false -Dbuild_benchmarks=false -Dbuild_tests=false
+cd ${NAME}/library
 
 echo "REPRIMAND: Building..."
-ninja -C mesonbuild
+${MAKE} -f ${SRCDIR}/../dist/Makefile DESTDIR=${REPRIMAND_DIR}
 
 echo "REPRIMAND: Installing..."
-meson install -C mesonbuild
-popd
+${MAKE} -f ${SRCDIR}/../dist/Makefile DESTDIR=${REPRIMAND_DIR} install
+popd >/dev/null
 
 echo "REPRIMAND: Cleaning up..."
 rm -rf ${BUILD_DIR}

--- a/ET_interface/thorns/RePrimAnd/src/make.code.deps
+++ b/ET_interface/thorns/RePrimAnd/src/make.code.deps
@@ -1,6 +1,7 @@
 # Main make.code.deps file for thorn RePrimAnd
 
 export REPRIMAND_INSTALL_DIR
+export BOOST_INC_DIRS GSL_INC_DIRS HDF5_INC_DIRS
 
 $(CCTK_TARGET) $(OBJS) $(SRCS:%=%.d): $(SCRATCH_BUILD)/done/$(THORN)
 


### PR DESCRIPTION
This adds a very simple Makefile to build the reprimand library for use inside of the ET.

It is not a full build system since it does not record any dependencies or lets one build docs or tests. It is *only* intended to be able to build from a freshly untarred tarbal, under control of the ET build system.

Fixes some issues that are present in the meson based build system, namely that the `XXX_INC_DIRS` and `XXX_LIB_DIRS` for HDF5 and BOOST must be communicated to meson to use those (instead of whather pkg-config may report).