### PR TITLE
ET_interface: set LIB_DIRS, INC_DIRS and LIBS if not specified

### DIFF
--- a/ET_interface/thorns/RePrimAnd/src/detect.sh
+++ b/ET_interface/thorns/RePrimAnd/src/detect.sh
@@ -69,8 +69,15 @@ echo "REPRIMAND_BUILD       = ${REPRIMAND_BUILD}"
 echo "REPRIMAND_INSTALL_DIR = ${REPRIMAND_INSTALL_DIR}"
 echo "END MAKE_DEFINITION"
 
+# Set default options if not all variables were set by user input
+if [ "${REPRIMAND_DIR}" != 'NO_BUILD' ]; then
+    : ${REPRIMAND_INC_DIRS="${REPRIMAND_DIR}/include"}
+    : ${REPRIMAND_LIB_DIRS="${REPRIMAND_DIR}/lib"}
+fi
+: ${REPRIMAND_LIBS='RePrimAnd'}
 
-set_make_vars "REPRIMAND" "$REPRIMAND_LIBS" "$REPRIMAND_LIB_DIRS" "$REPRIMAND_INC_DIRS"
+REPRIMAND_LIB_DIRS="$(${CCTK_HOME}/lib/sbin/strip-libdirs.sh $REPRIMAND_LIB_DIRS)"
+REPRIMAND_INC_DIRS="$(${CCTK_HOME}/lib/sbin/strip-incdirs.sh $REPRIMAND_INC_DIRS)"
 
 # Pass options to Cactus
 echo "BEGIN MAKE_DEFINITION"


### PR DESCRIPTION
This removes use of `set_make_vars` and ensures instead makes sure that values for `REPRIMAND_INC_DIRS`, `REPRIMAND_LIB_DIRS`, `REPRIMAND_LIBS` are provided if (and only if) they are not yet provided by the user (or build code).

`set_make_vars` does unexpected things if, on input, `REPRIMAND_LIB_DIRS` is not set, and even if it is set it will overwrite the (potentially user specified) `REPRIMAND_DIR` based on some assumption on how directories should be organized.

This is pull request makes RePrimAnd behave more like (most) other ExternalLibraries and is more respectful of user choices.